### PR TITLE
Fix missing state error sagemaker

### DIFF
--- a/aws/resource_aws_sagemaker_endpoint.go
+++ b/aws/resource_aws_sagemaker_endpoint.go
@@ -103,6 +103,10 @@ func resourceAwsSagemakerEndpointRead(d *schema.ResourceData, meta interface{}) 
 
 	endpointRaw, _, err := SagemakerEndpointStateRefreshFunc(conn, d.Id())()
 	if err != nil {
+		if sagemakerErr, ok := err.(awserr.Error); ok && sagemakerErr.Code() == "ValidationException" {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	if endpointRaw == nil {

--- a/aws/resource_aws_sagemaker_endpoint_configuration.go
+++ b/aws/resource_aws_sagemaker_endpoint_configuration.go
@@ -140,7 +140,7 @@ func resourceAwsSagemakerEndpointConfigurationRead(d *schema.ResourceData, meta 
 
 	endpointConfig, err := conn.DescribeEndpointConfig(request)
 	if err != nil {
-		if sagemakerErr, ok := err.(awserr.Error); ok && sagemakerErr.Code() == "ResourceNotFound" {
+		if sagemakerErr, ok := err.(awserr.Error); ok && sagemakerErr.Code() == "ValidationException" {
 			d.SetId("")
 			return nil
 		}

--- a/aws/resource_aws_sagemaker_model.go
+++ b/aws/resource_aws_sagemaker_model.go
@@ -140,7 +140,7 @@ func resourceAwsSagemakerModelRead(d *schema.ResourceData, meta interface{}) err
 
 	model, err := conn.DescribeModel(request)
 	if err != nil {
-		if sagemakerErr, ok := err.(awserr.Error); ok && sagemakerErr.Code() == "ResourceNotFound" {
+		if sagemakerErr, ok := err.(awserr.Error); ok && sagemakerErr.Code() == "ValidationException" {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Update the sagemaker_endpoint_configuration ResourceNotFound error to the actual message when running with terraform v0.11.5 and added the same behaviour to sagemaker_endpoint